### PR TITLE
Update common.md

### DIFF
--- a/docs/book/src/development/common.md
+++ b/docs/book/src/development/common.md
@@ -62,7 +62,7 @@
 
 6. Install calico on the workload cluster so that pods can see each other
     ```
-    KUBECONFIG=capc-cluster.kubeconfig kubectl apply -f https://projectcalico.docs.tigera.io/manifests/calico.yaml
+    KUBECONFIG=capc-cluster.kubeconfig kubectl apply -f https://raw.githubusercontent.com/weaveworks/weave/master/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
     ```
 
 7. Verify the K8s cluster is fully up.  (It may take a minute for the nodes status to all reach *ready* state.)


### PR DESCRIPTION

Updated the documentation 

The link to install CNI "https://projectcalico.docs.tigera.io/manifests/calico.yaml" is valid anymore  so updated with 

KUBECONFIG=capc-cluster.kubeconfig kubectl apply -f https://raw.githubusercontent.com/weaveworks/weave/master/prog/weave-kube/weave-daemonset-k8s-1.11.yaml
